### PR TITLE
Inline footnote

### DIFF
--- a/notes.tex
+++ b/notes.tex
@@ -32,7 +32,7 @@
 \author{Dominic Orchard \\
   {\small{School of Computing, University of Kent}}}
 
-\date{Last updated on \today}
+\date{Version 1.0.0.0}
 
 \begin{document}
 \maketitle
@@ -42,7 +42,7 @@ a counterpart to the lectures, but do not replace them; the lectures
 will provide content, detail, and discussion not given in these notes.
 
 These notes also provide a counterpart to the course textbook,
-\emph{Logic in Computer Science} (by Huth and Ryan) which I 
+\emph{Logic in Computer Science by Huth and Ryan} which I 
 recommend. We will only cover material from the first two chapters due
 to the short length of this part of the course. I recommend reading
 these chapters, but the assessable material for this course is
@@ -88,8 +88,7 @@ a logical argument. These rules represent the derivation of one formula
     \; {(\textit{label})}
 \end{equation*}
 %
-Each logical operator\footnote{Sometimes logical operators are
-  referred to as \emph{connectives}.} (like conjunction $\wedge$ and
+Each logical operator ( also referred to as \emph{connective}) (like conjunction $\wedge$ and
 disjunction $\vee$) will have one or more rules for \emph{introducing}
 that operator (deriving a conclusion using that operator) and one or
 more rules for \emph{eliminating} that operator (deriving a conclusion from a formula
@@ -114,7 +113,7 @@ following:
 But this isn't always the most helpful format to derive the
 proofs. Instead, we'll use a special ``box''-like notation called
 Fitch-style which you can find in the recommend reading textbook
-\emph{Logic in Computer Science} by Huth and Ryan.
+\emph{Logic in Computer Science} by \emph{Huth} and \emph{Ryan}.
 We will still apply the rules of natural deduction, but the Fitch-style
 gives us a nice way to layout the proof as we are deriving it.
 


### PR DESCRIPTION
Idea: Jumping to footnotes can break the flow of reading. Use them sparingly where it doesn't make sense to include the information in the body (e.g. attributions or links).