### PR TITLE
Inline footnote

### DIFF
--- a/notes.tex
+++ b/notes.tex
@@ -88,7 +88,7 @@ a logical argument. These rules represent the derivation of one formula
     \; {(\textit{label})}
 \end{equation*}
 %
-Each logical operator, also referred to as \emph{connective} (like conjunction $\wedge$ and
+Each logical operator (like conjunction $\wedge$ and
 disjunction $\vee$), will have one or more rules for \emph{introducing}
 that operator (deriving a conclusion using that operator) and one or
 more rules for \emph{eliminating} that operator (deriving a conclusion from a formula
@@ -128,7 +128,8 @@ propositional logic as $\bot$ (pronounced
   in a situation where anything could be true as we've arrived at a
   logically inconsistent situation. This is sometimes quite useful for
   doing proofs-by-contradiction, as we will see in
-  Section~\ref{sec:negation}.}
+  Section~\ref{sec:negation}.} Note that, in the literature, logical operators
+  are sometimes alternatively called \emph{logical connectives}.
 
 \subsection{Properties of formulas}
 

--- a/notes.tex
+++ b/notes.tex
@@ -88,9 +88,8 @@ a logical argument. These rules represent the derivation of one formula
     \; {(\textit{label})}
 \end{equation*}
 %
-Each logical operator\footnote{Sometimes logical operators are
-  referred to as \emph{connectives}.} (like conjunction $\wedge$ and
-disjunction $\vee$) will have one or more rules for \emph{introducing}
+Each logical operator, also referred to as \emph{connective} (like conjunction $\wedge$ and
+disjunction $\vee$), will have one or more rules for \emph{introducing}
 that operator (deriving a conclusion using that operator) and one or
 more rules for \emph{eliminating} that operator (deriving a conclusion from a formula
 using that operator). These rules can be stacked together to form a


### PR DESCRIPTION
Idea: Jumping to footnotes can break the flow of reading. Use them sparingly where it doesn't make sense to include the information in the body (e.g. attributions or links).