### PR TITLE
Add hidelinks option to hyperref package

### DIFF
--- a/notes.tex
+++ b/notes.tex
@@ -12,7 +12,7 @@
 % For restatables
 \usepackage{thmtools}
 \usepackage{thm-restate}
-\usepackage{hyperref}
+\usepackage[hidelinks]{hyperref}
 \usepackage{cleveref}
 
 \theoremstyle{definition}


### PR DESCRIPTION
Some PDF viewers will put brightly coloured boxes around hyperlinks without that option.