### PR TITLE
Fix usage of i.e. without \ie command

### DIFF
--- a/partA-notes.tex
+++ b/partA-notes.tex
@@ -225,7 +225,7 @@ to something like this if we needed it:
 %
 What about elimination?
 Reading the highlighted line in the truth table from right-to-left shows how to
-\emph{eliminate} a conjunction, i.e., what smaller formulas
+\emph{eliminate} a conjunction, \ie{}, what smaller formulas
 can we conclude are true if we know that $P \wedge Q$ is true? We get
 two rules:
 %


### PR DESCRIPTION
Only 1 instance I think, the rest used `\ie{}`.