### PR TITLE
 use bookmark package, add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.aux
+*.log
+*.out
+*.fdb_latexmk
+*.fls
+*.synctex.gz

--- a/notes.tex
+++ b/notes.tex
@@ -24,6 +24,7 @@
 \usepackage{thm-restate}
 \usepackage[hidelinks]{hyperref}
 \usepackage{cleveref}
+\usepackage[open=true]{bookmark}
 
 \theoremstyle{definition}
 \newtheorem{definition}{Definition}

--- a/notes.tex
+++ b/notes.tex
@@ -78,25 +78,19 @@ the task of remembering what you need to work on. You can then look
 back at this list when you are studying, and eventually cross off items
 as you get to grips with the material.
 
-\part{Propositional logic \& its natural deduction
-      proofs}
-
+\part{Propositional logic \& its natural deduction proofs}
 \input{partA-notes.tex}
 
 \part{Modelling systems using logic}
 \setcounter{section}{0}
-
 \input{partB-notes.tex}
 
 \part{Satisfiability for propositional logic}
 \setcounter{section}{0}
-
 \input{partC-notes.tex}
 
-\part{First-order logic and its natural deduction
-  proofs}
+\part{First-order logic and its natural deduction proofs}
 \setcounter{section}{0}
-
 \input{partD-notes.tex}
 
 \newpage


### PR DESCRIPTION
The table of content is nested incorrectly for PDF viewers. Here is a screenshot:

![Before](https://i.imgur.com/AmP9EMU.png)

The [bookmark package][1] fixes this issue: (it also expands TOC by default)

![After](https://i.imgur.com/vLW013f.png)

I have also added `.gitignore` to ignore some automatically generated files.

[1]:https://ctan.org/pkg/bookmark?lang=en