### PR TITLE
fix bookmark hyperlinks

### DIFF
--- a/notes.tex
+++ b/notes.tex
@@ -22,9 +22,9 @@
 % For restatables
 \usepackage{thmtools}
 \usepackage{thm-restate}
-\usepackage[hidelinks]{hyperref}
+\usepackage[hypertexnames=false, hidelinks]{hyperref}
 \usepackage{cleveref}
-\usepackage[open=true]{bookmark}
+\usepackage[numbered, open=true]{bookmark}
 
 \theoremstyle{definition}
 \newtheorem{definition}{Definition}


### PR DESCRIPTION
Since section counters are being reset with each part  ([#line85][L85], [#line89][L89], [#line93][L93]), the pdf bookmark hyperlinks are linking to the wrong sections: (You can see that by looking at the page numbers)

![Before](https://i.imgur.com/t6iM3LB.png)

**Solution**: set the [`hypertexnames`][1] option to false for `hyperref` to reference from the corresponding counter value instead of a shared counter: ([This question][Q] on TeX SE address this issue)

![After](https://i.imgur.com/n5ScmoL.png)

I have also numbered the pdf bookmarks by using the `numbered` option for the `bookmark` package.

(My bad, I should've noticed and fixed that at the same time on my first PR.)

[1]:http://mirror.ox.ac.uk/sites/ctan.org/macros/latex/contrib/hyperref/doc/manual.html#TBL-3

[L85]:https://github.com/dorchard/co519-logic/blob/3aa8ce7118aace5b04d6fadc5b43759a74d5c447/notes.tex#L85
[L89]:https://github.com/dorchard/co519-logic/blob/3aa8ce7118aace5b04d6fadc5b43759a74d5c447/notes.tex#L89
[L93]:https://github.com/dorchard/co519-logic/blob/3aa8ce7118aace5b04d6fadc5b43759a74d5c447/notes.tex#L93

[Q]:https://tex.stackexchange.com/q/6098/171942