### PR TITLE
Fix minor typo

### DIFF
--- a/partD-notes.tex
+++ b/partD-notes.tex
@@ -494,7 +494,7 @@ a variable in scope but also has assumptions.
 
 \begin{example}
 Prove $\exists x . \rel{P}(x) \wedge \rel{Q}(x)
-\vdash \exists x . \rel{P}(x)$ is valid.
+\vdash \exists y . \rel{P}(y)$ is valid.
 
 \begin{logicproof}{2}
 \exists x . \rel{P}(x) \wedge \rel{Q}(x)  & premise \\


### PR DESCRIPTION
Rename bound variable `x` to `y` in example 17 statement.