### PR TITLE
fix incorrect paragraph title

### DIFF
--- a/partD-notes.tex
+++ b/partD-notes.tex
@@ -455,7 +455,7 @@ rather directly prove the following:
    \end{logicproof}
  \end{example}
  %
- \paragraph{Introduction} Recall disjunction introduction is:
+ \paragraph{Elimination} Recall disjunction elimination is:
  %
 \begin{align*}
 \setlength{\arraycolsep}{0em}


### PR DESCRIPTION
Hello,

There is an incorrect paragraph title at [line 458](https://github.com/dorchard/co519-logic/blob/c8918dc5d2da3049ad5c9aaa3b71e0f04f995b87/partD-notes.tex#L458)

It should be "**Elimination** Recall disjunction elimination is:"

PR submitted and a screenshot of error can be found below:

---

![Screenshot from 2019-05-19 16-34-11](https://user-images.githubusercontent.com/17771168/57984475-028ac080-7a54-11e9-92e7-486670f52110.png)